### PR TITLE
Fix build errors with README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ let mft = Mft::new(volume)?;
 // Iterate all files
 mft.iterate_files(|file| {
     // Can also use FileInfo::with_cache().
-    let info = FileInfo::new(mft, file);
+    let info = FileInfo::new(&mft, file);
 
     // Available fields: name, path, is_directory, size, timestamps (created, accessed, modified).
 });
@@ -39,7 +39,7 @@ let volume = Volume::new("\\\\?\\C:")?;
 
 // With `JournalOptions` you can customize things like where to start reading
 // from (beginning, end, specific point), the mask to use for the events and more.
-let journal = Journal::new(volume, JournalOptions::default())?;
+let mut journal = Journal::new(volume, JournalOptions::default())?;
 
 // Try to read some events.
 // You can call `read_sized` to use a custom buffer size.


### PR DESCRIPTION
Two small fixes to fix build errors with the examples.